### PR TITLE
Fix about page external link security

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,7 @@
         </p>
         <h2>İletişim</h2>
         <p>
-            Bizimle iletişime geçmek, bir konu önermek veya sadece merhaba demek mi istiyorsunuz? Şuradan mail atın; <a href="mailto:genelojipod@gmail.com">genelojipod@gmail.com</a> ya da buradan takip edin; <a href="https://instagram.com/acikbufediyalog" target="_blank">Instagram</a>.
+            Bizimle iletişime geçmek, bir konu önermek veya sadece merhaba demek mi istiyorsunuz? Şuradan mail atın; <a href="mailto:genelojipod@gmail.com">genelojipod@gmail.com</a> ya da buradan takip edin; <a href="https://instagram.com/acikbufediyalog" target="_blank" rel="noopener noreferrer">Instagram</a>.
         </p>
     </section>
     <footer>


### PR DESCRIPTION
## Summary
- update the Instagram link in about.html to add `rel="noopener noreferrer"` when opening in a new tab

## Testing
- `grep -n "noopener" -n about.html`

------
https://chatgpt.com/codex/tasks/task_e_68403da098ec8329a97e497792bd676e